### PR TITLE
Add new flag to suppress byte progess counter.

### DIFF
--- a/contracts/config_upload.go
+++ b/contracts/config_upload.go
@@ -13,6 +13,7 @@ type UploadConfig struct {
 	GoogleCredentials gcs.Credentials
 	JSONPath          string
 	Overwrite         bool
+	ShowProgress      bool
 	PackageConfig     PackageConfig
 }
 

--- a/core/builder.go
+++ b/core/builder.go
@@ -22,19 +22,21 @@ type FilePackageBuilderFileSystem interface {
 }
 
 type FilePackageBuilder struct {
-	sourceFile string
-	writer     io.Writer
-	hasher     hash.Hash
-	contents   []contracts.ArchiveItem
-	fileSystem FilePackageBuilderFileSystem
+	sourceFile   string
+	writer       io.Writer
+	hasher       hash.Hash
+	contents     []contracts.ArchiveItem
+	fileSystem   FilePackageBuilderFileSystem
+	showProgress bool
 }
 
-func NewFilePackageBuilder(sourceFile string, writer io.Writer, fileSystem FilePackageBuilderFileSystem, hasher hash.Hash) PackageBuilder {
+func NewFilePackageBuilder(sourceFile string, writer io.Writer, fileSystem FilePackageBuilderFileSystem, hasher hash.Hash, showProgress bool) PackageBuilder {
 	return &FilePackageBuilder{
-		sourceFile: sourceFile,
-		writer:     writer,
-		hasher:     hasher,
-		fileSystem: fileSystem,
+		sourceFile:   sourceFile,
+		writer:       writer,
+		hasher:       hasher,
+		fileSystem:   fileSystem,
+		showProgress: showProgress,
 	}
 }
 
@@ -73,17 +75,19 @@ type DirectoryPackageBuilderFileSystem interface {
 }
 
 type DirectoryPackageBuilder struct {
-	storage  DirectoryPackageBuilderFileSystem
-	archive  contracts.ArchiveWriter
-	hasher   hash.Hash
-	contents []contracts.ArchiveItem
+	storage      DirectoryPackageBuilderFileSystem
+	archive      contracts.ArchiveWriter
+	hasher       hash.Hash
+	contents     []contracts.ArchiveItem
+	showProgress bool
 }
 
-func NewDirectoryPackageBuilder(storage DirectoryPackageBuilderFileSystem, archive contracts.ArchiveWriter, hasher hash.Hash) PackageBuilder {
+func NewDirectoryPackageBuilder(storage DirectoryPackageBuilderFileSystem, archive contracts.ArchiveWriter, hasher hash.Hash, showProgress bool) PackageBuilder {
 	return &DirectoryPackageBuilder{
-		storage: storage,
-		archive: archive,
-		hasher:  hasher,
+		storage:      storage,
+		archive:      archive,
+		hasher:       hasher,
+		showProgress: showProgress,
 	}
 }
 
@@ -118,7 +122,9 @@ func (this *DirectoryPackageBuilder) archiveContents(file contracts.FileInfo, sy
 		return nil
 	}
 	progressWriter := newArchiveProgressCounter(file.Size(), func(archived, total string) {
-		fmt.Printf("\033[2K\rArchived %s of %s.", archived, total)
+		if this.showProgress {
+			fmt.Printf("\033[2K\rArchived %s of %s.", archived, total)
+		}
 	})
 	defer func() {
 		fmt.Printf("\n")

--- a/core/builder_test.go
+++ b/core/builder_test.go
@@ -25,7 +25,7 @@ func (this *DirectoryPackageBuilderFixture) Setup() {
 	this.fileSystem = newInMemoryFileSystem()
 	this.archive = NewFakeArchiveWriter()
 	this.hasher = NewFakeHasher()
-	this.builder = NewDirectoryPackageBuilder(this.fileSystem, this.archive, this.hasher)
+	this.builder = NewDirectoryPackageBuilder(this.fileSystem, this.archive, this.hasher, true)
 	this.fileSystem.WriteFile("/in/file0.txt", []byte("a"))
 	_ = this.fileSystem.Chmod("/in/file0.txt", 0755)
 	this.fileSystem.WriteFile("/in/file1.txt", []byte("bb"))

--- a/core/installer.go
+++ b/core/installer.go
@@ -28,12 +28,13 @@ type PackageInstallerFileSystem interface {
 }
 
 type PackageInstaller struct {
-	downloader contracts.Downloader
-	filesystem PackageInstallerFileSystem
+	downloader   contracts.Downloader
+	filesystem   PackageInstallerFileSystem
+	showProgress bool
 }
 
-func NewPackageInstaller(downloader contracts.Downloader, filesystem PackageInstallerFileSystem) *PackageInstaller {
-	return &PackageInstaller{downloader: downloader, filesystem: filesystem}
+func NewPackageInstaller(downloader contracts.Downloader, filesystem PackageInstallerFileSystem, showProgress bool) *PackageInstaller {
+	return &PackageInstaller{downloader: downloader, filesystem: filesystem, showProgress: showProgress}
 }
 
 func (this *PackageInstaller) DownloadManifest(remoteAddress url.URL) (manifest contracts.Manifest, err error) {
@@ -123,7 +124,9 @@ func (this *PackageInstaller) extractArchive(decompressor io.ReadCloser, request
 		} else {
 			writer := this.filesystem.Create(pathItem)
 			progressReader := newArchiveProgressCounter(header.Size, func(archived, total string) {
-				fmt.Printf("\033[2K\rExtracted %s of %s.", archived, total)
+				if this.showProgress {
+					fmt.Printf("\033[2K\rExtracted %s of %s.", archived, total)
+				}
 			})
 			multiWriter := io.MultiWriter(writer, progressReader)
 			_, err = io.Copy(multiWriter, reader)

--- a/core/installer_test.go
+++ b/core/installer_test.go
@@ -33,7 +33,7 @@ type PackageInstallerFixture struct {
 func (this *PackageInstallerFixture) Setup() {
 	this.downloader = &FakeDownloader{}
 	this.filesystem = newInMemoryFileSystem()
-	this.installer = NewPackageInstaller(this.downloader, this.filesystem)
+	this.installer = NewPackageInstaller(this.downloader, this.filesystem, true)
 }
 
 func (this *PackageInstallerFixture) TestInstallManifest() {

--- a/core/upload_config_loader.go
+++ b/core/upload_config_loader.go
@@ -85,6 +85,11 @@ func (this *UploadConfigLoader) parseCLI(name string, args []string) (config con
 		false,
 		"When set, always upload package, even when it already exists at specified remote location.",
 	)
+	flags.BoolVar(&config.ShowProgress,
+		"progress",
+		true,
+		"Displays progress stats as files are added to the archive.",
+	)
 	flags.Usage = func() {
 		_, _ = fmt.Fprintf(this.stderr, "Usage of satisfy %s:", name)
 		flags.PrintDefaults()

--- a/transfer/config_download.go
+++ b/transfer/config_download.go
@@ -18,6 +18,7 @@ import (
 type DownloadConfig struct {
 	MaxRetry          int
 	QuickVerification bool
+	ShowProgress      bool
 	GoogleCredentials gcs.Credentials
 	Dependencies      contracts.DependencyListing
 	jsonPath          string
@@ -34,6 +35,11 @@ func ParseDownloadConfig(args []string) (config DownloadConfig, err error) {
 		"quick",
 		true,
 		"When set to false, perform full file content validation on installed packages.",
+	)
+	flags.BoolVar(&config.ShowProgress,
+		"progress",
+		true,
+		"Displays progress stats as files are extracted from the archive.",
 	)
 	flags.StringVar(&config.jsonPath,
 		"json",

--- a/transfer/download.go
+++ b/transfer/download.go
@@ -23,7 +23,7 @@ type DownloadApp struct {
 func NewDownloadApp(config DownloadConfig) *DownloadApp {
 	disk := shell.NewDiskFileSystem("")
 	client := shell.NewGoogleCloudStorageClient(shell.NewHTTPClient(), config.GoogleCredentials, http.StatusOK)
-	installer := core.NewPackageInstaller(core.NewRetryClient(client, config.MaxRetry, time.Sleep), disk)
+	installer := core.NewPackageInstaller(core.NewRetryClient(client, config.MaxRetry, time.Sleep), disk, config.ShowProgress)
 	integrity := core.NewCompoundIntegrityCheck(
 		core.NewFileListingIntegrityChecker(disk),
 		core.NewFileContentIntegrityCheck(md5.New, disk, !config.QuickVerification),

--- a/transfer/upload.go
+++ b/transfer/upload.go
@@ -102,6 +102,7 @@ func (this *UploadApp) buildArchiveAndManifestContents() {
 			shell.NewDiskFileSystem(this.packageConfig.SourceDirectory),
 			shell.NewSwitchArchiveWriter(this.compressor),
 			md5.New(),
+			this.config.ShowProgress,
 		)
 	} else {
 		this.builder = core.NewFilePackageBuilder(
@@ -109,6 +110,7 @@ func (this *UploadApp) buildArchiveAndManifestContents() {
 			writer,
 			shell.NewDiskFileSystem(filepath.Dir(this.config.PackageConfig.SourceFile)),
 			this.hasher,
+			this.config.ShowProgress,
 		)
 	}
 


### PR DESCRIPTION
When run in an automated fashion, the byte progress counter is not log friendly. This pull request adds a new flag to suppress that counter.  It will still show the progress counter by default.